### PR TITLE
Hotfix clinic after mvp

### DIFF
--- a/resources/views/clinic/consultations/edit.blade.php
+++ b/resources/views/clinic/consultations/edit.blade.php
@@ -138,7 +138,7 @@
                                 Temperature (°C)
                             </label>
                             <input type="number"
-                                step="0.01"
+                                step="0.1"
                                 name="temperature"
                                 value="{{ old('temperature', $consultation->temperature) }}"
                                 class="w-full rounded-lg border border-neutral-300 bg-white px-4 py-2 text-sm text-neutral-900


### PR DESCRIPTION
- Fixed temperature formatting in edit consultation form to remove trailing zeros (e.g., 37.60 → 37.6)
- Merged latest changes from main into the hotfix branch to ensure up-to-date codebase compatibility