### PR TITLE
Profile settings: add dietary/medical fields and two-column layout

### DIFF
--- a/app/Livewire/Settings/Profile2.php
+++ b/app/Livewire/Settings/Profile2.php
@@ -22,6 +22,8 @@ class Profile2 extends Component
     public string $emergency_contact_name = '';
     public string $emergency_contact_relationship = '';
     public string $emergency_contact_phone = '';
+    public string $dietary_preference = '';
+    public string $medical_notes = '';
 
     public $avatar;
 
@@ -40,6 +42,8 @@ class Profile2 extends Component
         $this->emergency_contact_name = $user->emergency_contact_name ?? '';
         $this->emergency_contact_relationship = $user->emergency_contact_relationship ?? '';
         $this->emergency_contact_phone = $user->emergency_contact_phone ?? '';
+        $this->dietary_preference = $user->dietary_preference ?? '';
+        $this->medical_notes = $user->medical_notes ?? '';
     }
 
     public function updateAvatar(): void
@@ -90,6 +94,8 @@ class Profile2 extends Component
             'emergency_contact_name' => ['nullable', 'string', 'max:255'],
             'emergency_contact_relationship' => ['nullable', 'string', Rule::in($this->relationshipOptions)],
             'emergency_contact_phone' => ['nullable', 'regex:/^\+?[0-9]{7,15}$/'],
+            'dietary_preference' => ['nullable', 'string', 'max:255'],
+            'medical_notes' => ['nullable', 'string', 'max:2000'],
         ]);
 
         $user->update($validated);
@@ -109,6 +115,8 @@ class Profile2 extends Component
             'emergency_contact_name' => $user->emergency_contact_name ?? '',
             'emergency_contact_relationship' => $user->emergency_contact_relationship ?? '',
             'emergency_contact_phone' => $user->emergency_contact_phone ?? '',
+            'dietary_preference' => $user->dietary_preference ?? '',
+            'medical_notes' => $user->medical_notes ?? '',
         ]);
 
         $this->dispatch('flash', type: 'success', message: 'Profile updated.');

--- a/resources/views/livewire/settings/profile2.blade.php
+++ b/resources/views/livewire/settings/profile2.blade.php
@@ -9,69 +9,77 @@
             <!-- FORM -->
             <div class="md:col-span-2 w-full">
 
-                <form wire:submit.prevent="updateProfileInformation" class="space-y-4">
+                <form wire:submit.prevent="updateProfileInformation" class="space-y-6">
 
-                    <!-- Name -->
-                    <div>
-                        <label class="block text-sm font-medium text-zinc-700 dark:text-zinc-300 mb-1">
-                            Name
-                        </label>
-                        <input type="text" wire:model="name"
-                            class="w-full rounded-lg border border-zinc-300 dark:border-zinc-700 bg-white dark:bg-zinc-800 px-3 py-2 text-sm"
-                            required>
-                        @error('name')
-                            <div class="text-red-500 text-xs mt-1">{{ $message }}</div>
-                        @enderror
-                    </div>
+                    <div class="grid grid-cols-1 md:grid-cols-2 gap-6 items-start">
 
-                    <!-- Preferred Name -->
-                    <div>
-                        <label class="block text-sm font-medium text-zinc-700 dark:text-zinc-300 mb-1">
-                            Preferred Name
-                        </label>
-                        <input type="text" wire:model="preferred_name"
-                            class="w-full rounded-lg border border-zinc-300 dark:border-zinc-700 bg-white dark:bg-zinc-800 px-3 py-2 text-sm">
-                    </div>
-
-                    <!-- Email -->
-                    <div>
-                        <label class="block text-sm font-medium text-zinc-700 dark:text-zinc-300 mb-1">
-                            Email
-                        </label>
-                        <input type="email" wire:model="email"
-                            class="w-full rounded-lg border border-zinc-300 dark:border-zinc-700 bg-zinc-100 dark:bg-zinc-800 px-3 py-2 text-sm"
-                            readonly>
-                    </div>
-
-                    <!-- Work Phone -->
-                    <div>
-                        <label class="block text-sm font-medium text-zinc-700 dark:text-zinc-300 mb-1">
-                            Work Phone
-                        </label>
-                        <input type="text" wire:model="phone_work"
-                            class="w-full rounded-lg border border-zinc-300 dark:border-zinc-700 bg-white dark:bg-zinc-800 px-3 py-2 text-sm">
-                    </div>
-
-                    <!-- Mobile Phone -->
-                    <div>
-                        <label class="block text-sm font-medium text-zinc-700 dark:text-zinc-300 mb-1">
-                            Mobile Phone
-                        </label>
-                        <input type="text" wire:model="phone_mobile"
-                            class="w-full rounded-lg border border-zinc-300 dark:border-zinc-700 bg-white dark:bg-zinc-800 px-3 py-2 text-sm">
-                    </div>
-
-                    <!-- Emergency Contact -->
-                    <div class="pt-4 mt-2 border-t border-zinc-200 dark:border-zinc-700">
-                        <h3 class="text-sm font-semibold text-zinc-700 dark:text-zinc-300 mb-3">
-                            Emergency Contact
-                        </h3>
-
+                        {{-- ============ LEFT: Personal Information ============ --}}
                         <div class="space-y-4">
+                            <h3 class="text-sm font-semibold text-zinc-700 dark:text-zinc-300 pb-2 border-b border-zinc-200 dark:border-zinc-700">
+                                Personal Information
+                            </h3>
+
+                            <!-- Name -->
+                            <div>
+                                <label class="block text-sm font-medium text-zinc-700 dark:text-zinc-300 mb-1">
+                                    Name
+                                </label>
+                                <input type="text" wire:model="name"
+                                    class="w-full rounded-lg border border-zinc-300 dark:border-zinc-700 bg-white dark:bg-zinc-800 px-3 py-2 text-sm"
+                                    required>
+                                @error('name')
+                                    <div class="text-red-500 text-xs mt-1">{{ $message }}</div>
+                                @enderror
+                            </div>
+
+                            <!-- Preferred Name -->
+                            <div>
+                                <label class="block text-sm font-medium text-zinc-700 dark:text-zinc-300 mb-1">
+                                    Preferred Name
+                                </label>
+                                <input type="text" wire:model="preferred_name"
+                                    class="w-full rounded-lg border border-zinc-300 dark:border-zinc-700 bg-white dark:bg-zinc-800 px-3 py-2 text-sm">
+                            </div>
+
+                            <!-- Email -->
+                            <div>
+                                <label class="block text-sm font-medium text-zinc-700 dark:text-zinc-300 mb-1">
+                                    Email
+                                </label>
+                                <input type="email" wire:model="email"
+                                    class="w-full rounded-lg border border-zinc-300 dark:border-zinc-700 bg-zinc-100 dark:bg-zinc-800 px-3 py-2 text-sm"
+                                    readonly>
+                            </div>
+
+                            <!-- Work Phone -->
+                            <div>
+                                <label class="block text-sm font-medium text-zinc-700 dark:text-zinc-300 mb-1">
+                                    Work Phone
+                                </label>
+                                <input type="text" wire:model="phone_work"
+                                    class="w-full rounded-lg border border-zinc-300 dark:border-zinc-700 bg-white dark:bg-zinc-800 px-3 py-2 text-sm">
+                            </div>
+
+                            <!-- Mobile Phone -->
+                            <div>
+                                <label class="block text-sm font-medium text-zinc-700 dark:text-zinc-300 mb-1">
+                                    Mobile Phone
+                                </label>
+                                <input type="text" wire:model="phone_mobile"
+                                    class="w-full rounded-lg border border-zinc-300 dark:border-zinc-700 bg-white dark:bg-zinc-800 px-3 py-2 text-sm">
+                            </div>
+                        </div>
+
+                        {{-- ============ RIGHT: Emergency & Health ============ --}}
+                        <div class="space-y-4">
+                            <h3 class="text-sm font-semibold text-zinc-700 dark:text-zinc-300 pb-2 border-b border-zinc-200 dark:border-zinc-700">
+                                Emergency &amp; Health
+                            </h3>
+
                             <!-- Contact Person -->
                             <div>
                                 <label class="block text-sm font-medium text-zinc-700 dark:text-zinc-300 mb-1">
-                                    Contact Person
+                                    Emergency Contact Person
                                 </label>
                                 <input type="text" wire:model="emergency_contact_name"
                                     placeholder="Full name"
@@ -101,7 +109,7 @@
                             <!-- Contact Number -->
                             <div>
                                 <label class="block text-sm font-medium text-zinc-700 dark:text-zinc-300 mb-1">
-                                    Contact Number
+                                    Emergency Contact Number
                                 </label>
                                 <input type="text" wire:model="emergency_contact_phone"
                                     placeholder="+639171234567"
@@ -110,18 +118,9 @@
                                     <div class="text-red-500 text-xs mt-1">{{ $message }}</div>
                                 @enderror
                             </div>
-                        </div>
-                    </div>
 
-                    <!-- Health & Dietary -->
-                    <div class="pt-4 mt-2 border-t border-zinc-200 dark:border-zinc-700">
-                        <h3 class="text-sm font-semibold text-zinc-700 dark:text-zinc-300 mb-3">
-                            Health &amp; Dietary
-                        </h3>
-
-                        <div class="space-y-4">
                             <!-- Dietary Preference -->
-                            <div>
+                            <div class="pt-2">
                                 <label class="block text-sm font-medium text-zinc-700 dark:text-zinc-300 mb-1">
                                     Dietary Preference
                                 </label>
@@ -146,10 +145,11 @@
                                 @enderror
                             </div>
                         </div>
+
                     </div>
 
                     <!-- Submit -->
-                    <div class="flex items-center gap-4 pt-2">
+                    <div class="flex items-center gap-4 pt-2 border-t border-zinc-200 dark:border-zinc-700">
                         <flux:button type="submit" variant="primary" color="emerald">
                             Save
                         </flux:button>

--- a/resources/views/livewire/settings/profile2.blade.php
+++ b/resources/views/livewire/settings/profile2.blade.php
@@ -113,6 +113,41 @@
                         </div>
                     </div>
 
+                    <!-- Health & Dietary -->
+                    <div class="pt-4 mt-2 border-t border-zinc-200 dark:border-zinc-700">
+                        <h3 class="text-sm font-semibold text-zinc-700 dark:text-zinc-300 mb-3">
+                            Health &amp; Dietary
+                        </h3>
+
+                        <div class="space-y-4">
+                            <!-- Dietary Preference -->
+                            <div>
+                                <label class="block text-sm font-medium text-zinc-700 dark:text-zinc-300 mb-1">
+                                    Dietary Preference
+                                </label>
+                                <input type="text" wire:model="dietary_preference"
+                                    placeholder="e.g. None, Vegetarian, Halal"
+                                    class="w-full rounded-lg border border-zinc-300 dark:border-zinc-700 bg-white dark:bg-zinc-800 px-3 py-2 text-sm">
+                                @error('dietary_preference')
+                                    <div class="text-red-500 text-xs mt-1">{{ $message }}</div>
+                                @enderror
+                            </div>
+
+                            <!-- Allergies / Medical Notes -->
+                            <div>
+                                <label class="block text-sm font-medium text-zinc-700 dark:text-zinc-300 mb-1">
+                                    Allergies / Medical Notes
+                                </label>
+                                <textarea wire:model="medical_notes" rows="3"
+                                    placeholder="Allergies or medical conditions relevant to events"
+                                    class="w-full rounded-lg border border-zinc-300 dark:border-zinc-700 bg-white dark:bg-zinc-800 px-3 py-2 text-sm"></textarea>
+                                @error('medical_notes')
+                                    <div class="text-red-500 text-xs mt-1">{{ $message }}</div>
+                                @enderror
+                            </div>
+                        </div>
+                    </div>
+
                     <!-- Submit -->
                     <div class="flex items-center gap-4 pt-2">
                         <flux:button type="submit" variant="primary" color="emerald">

--- a/tests/Feature/Settings/ProfileEmergencyContactTest.php
+++ b/tests/Feature/Settings/ProfileEmergencyContactTest.php
@@ -84,4 +84,48 @@ class ProfileEmergencyContactTest extends TestCase
             ->call('updateProfileInformation')
             ->assertHasNoErrors();
     }
+
+    public function test_dietary_and_medical_fields_are_hydrated_on_mount(): void
+    {
+        $user = User::factory()->create([
+            'dietary_preference' => 'Vegetarian',
+            'medical_notes' => 'Peanut allergy',
+        ]);
+
+        Livewire::actingAs($user)
+            ->test(Profile2::class)
+            ->assertSet('dietary_preference', 'Vegetarian')
+            ->assertSet('medical_notes', 'Peanut allergy');
+    }
+
+    public function test_user_can_save_dietary_and_medical_details(): void
+    {
+        $user = User::factory()->create();
+
+        Livewire::actingAs($user)
+            ->test(Profile2::class)
+            ->set('name', $user->name)
+            ->set('email', $user->email)
+            ->set('dietary_preference', 'Halal')
+            ->set('medical_notes', 'Asthma; carries inhaler')
+            ->call('updateProfileInformation')
+            ->assertHasNoErrors();
+
+        $user->refresh();
+        $this->assertEquals('Halal', $user->dietary_preference);
+        $this->assertEquals('Asthma; carries inhaler', $user->medical_notes);
+    }
+
+    public function test_medical_notes_max_length_is_enforced(): void
+    {
+        $user = User::factory()->create();
+
+        Livewire::actingAs($user)
+            ->test(Profile2::class)
+            ->set('name', $user->name)
+            ->set('email', $user->email)
+            ->set('medical_notes', str_repeat('a', 2001))
+            ->call('updateProfileInformation')
+            ->assertHasErrors(['medical_notes']);
+    }
 }


### PR DESCRIPTION
## What & why
Follow-up to #18 (which added the emergency-contact fields). This completes the profile **personal details** work that landed after #18 was merged.

## Changes
- **Health & Dietary fields** added to Settings → Profile → Update your details:
  - Dietary Preference (text)
  - Allergies / Medical Notes (textarea, max 2000 chars)
- **Two-column layout** for the profile form:
  - Left — **Personal Information** (Name, Preferred Name, Email, Work/Mobile Phone)
  - Right — **Emergency & Health** (Emergency Contact person/relationship/number, Dietary Preference, Allergies/Medical Notes)
  - Single full-width Save below.

## Implementation
Extends the `Profile2` Livewire component + view: new properties, mount hydration, validation, update, rehydration; form markup reorganized into a responsive 2-column grid (stacks on mobile).

## Tests
`tests/Feature/Settings/ProfileEmergencyContactTest.php` extended to 8 tests (hydration, saving, relationship allow-list, phone validation, medical-notes max length). Full suite run before push: 61 passed; the only failures are 3 pre-existing default-scaffolding tests unrelated to this change.

## Notes
- Reuses the `dietary_preference` and `medical_notes` columns already on `users` — no migration needed.
- All 5 normalized personal-detail fields are now self-editable and grouped into two columns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
